### PR TITLE
Fixed EC2 Credentials

### DIFF
--- a/examples/terraform-ec2/data.tf
+++ b/examples/terraform-ec2/data.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 data "aws_ami" "amznlinux" {
   most_recent = true
 
@@ -15,4 +17,8 @@ data "template_file" "user_data" {
     aws_region = "${var.region}"
     s3_uri  = "${local.s3_uri}"
   }
+}
+
+data "aws_iam_policy" "security_audit" {
+  arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/SecurityAudit"
 }

--- a/examples/terraform-ec2/iam.tf
+++ b/examples/terraform-ec2/iam.tf
@@ -33,6 +33,11 @@ resource "aws_iam_role" "fedrampup" {
 EOF
 }
 
+resource "aws_iam_role_policy_attachment" "fedrampup_audit_attachment" {
+  role = "${aws_iam_role.fedrampup.name}"
+  policy_arn = "${data.aws_iam_policy.security_audit.arn}"
+}
+
 resource "aws_iam_role_policy_attachment" "fedrampup_attachment" {
   role       = "${aws_iam_role.fedrampup.name}"
   policy_arn = "${aws_iam_policy.fedrampup.arn}"

--- a/examples/terraform-ec2/user-data.tpl
+++ b/examples/terraform-ec2/user-data.tpl
@@ -18,8 +18,8 @@ mkdir -p /opt/go/src /opt/go/pkg /opt/go/bin
 WRAPPER=/opt/fedrampup-wrapper
 cat << EOF > $WRAPPER
 #!/bin/bash
-AWS_REGION=${aws_region}
-OUTPUT_FILE=${s3_uri}
+export AWS_REGION=${aws_region}
+export OUTPUT_FILE=${s3_uri}
 
 /opt/go/bin/fedrampup
 EOF


### PR DESCRIPTION
Go AWS SDK is not clear that the ec2metadata client must be created and attached to the `EC2RoleProvider` struct. If the client pointer is nil, the program will panic due to a nil memory dereference.

Also fixed some things in the terraform example that were found in the wild.